### PR TITLE
Send the socket id to the client

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -51,7 +51,7 @@ function setupSocketServer( server ) {
 			}
 			socket.broadcast
 				.to( roomID )
-				.emit( 'client-broadcast', data.action );
+				.emit( 'client-broadcast', data.action, socket.id );
 		} );
 
 		socket.on( 'server-volatile-broadcast', async ( roomID, data ) => {
@@ -63,7 +63,7 @@ function setupSocketServer( server ) {
 			}
 			socket.volatile.broadcast
 				.to( roomID )
-				.emit( 'client-broadcast', data.action );
+				.emit( 'client-broadcast', data.action, socket.id );
 		} );
 
 		socket.on( 'disconnecting', () => {


### PR DESCRIPTION
Just a small change to send the current socket id to the client. This allows to know which client broadcasted the message which is important for selections indicators